### PR TITLE
使用cnpm access ls-packages命令报404

### DIFF
--- a/routes/registry.js
+++ b/routes/registry.js
@@ -101,7 +101,7 @@ function routes(app) {
 
   // list all packages of user
   app.get('/-/by-user/:user', userPackage.list);
-  app.get('/-/users/:user/packages', listPackagesByUser);
+  app.get('/-/user/:user/package', listPackagesByUser);
 
   // download times
   app.get('/downloads/range/:range/:name', downloadTotal);


### PR DESCRIPTION
npm access ls-packages命令访问接口格式为http://registryhost/-/user/name/package?format=cli，原代码路由多了两个s，导致404